### PR TITLE
Add preprocessor condition to check LPP_UNIXTIME definition

### DIFF
--- a/CayenneLPP_Dec.cpp
+++ b/CayenneLPP_Dec.cpp
@@ -190,6 +190,7 @@ bool CayenneLPPDec::ParseLPP(const uint8_t *pBuffer, size_t Len, Json::Value &ro
 			pBuffer += LPP_BAROMETRIC_PRESSURE_SIZE;
 			Len -= LPP_BAROMETRIC_PRESSURE_SIZE;
 		} 
+#ifdef LPP_UNIXTIME
 		else if (lpp_type == LPP_UNIXTIME) {
 			if (Len < LPP_UNIXTIME_SIZE)
 				return false;
@@ -203,6 +204,7 @@ bool CayenneLPPDec::ParseLPP(const uint8_t *pBuffer, size_t Len, Json::Value &ro
 			pBuffer += LPP_UNIXTIME_SIZE;
 			Len -= LPP_UNIXTIME_SIZE;
 		}
+#endif // LPP_UNIXTIME
 		else if (lpp_type == LPP_GYROMETER) {
 			if (Len < LPP_GYROMETER_SIZE)
 				return false;


### PR DESCRIPTION
Original CayenneLPP library has no LPP_UNIXTIME definition. This is specified on http://www.openmobilealliance.org/wp/OMNA/LwM2M/LwM2MRegistry.html#extlabel with code 3333.